### PR TITLE
Don't blindly fetch the number of items in a section

### DIFF
--- a/MTCardLayout/MTCardLayout.m
+++ b/MTCardLayout/MTCardLayout.m
@@ -139,11 +139,12 @@
     effectiveBounds.size.height -= _metrics.listingInsets.top + _metrics.listingInsets.bottom;
 	rect = CGRectIntersection(rect, effectiveBounds);
     
-    NSRange range = rangeForVisibleCells(rect, [self.collectionView numberOfItemsInSection:0] , _metrics);
+    NSInteger numberOfItems = [self numberOfItemsInCollectionViewSection:0];
+    
+    NSRange range = rangeForVisibleCells(rect, numberOfItems, _metrics);
     
     NSMutableArray *cells = [NSMutableArray arrayWithCapacity:range.length + 2];
     
-	NSInteger numberOfItems = [self.collectionView numberOfItemsInSection:0];
 	NSIndexPath *selectedIndexPath = [[self.collectionView indexPathsForSelectedItems] firstObject];
 
     for (NSUInteger item=range.location; item < (range.location + range.length); item++)
@@ -162,7 +163,10 @@
 
 - (CGSize)collectionViewContentSize
 {
-    return collectionViewSize(self.collectionView.bounds, self.collectionView.contentInset, [self.collectionView numberOfItemsInSection:0], _metrics);
+    return collectionViewSize(self.collectionView.bounds,
+                              self.collectionView.contentInset,
+                              [self numberOfItemsInCollectionViewSection:0],
+                              _metrics);
 }
 
 - (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds
@@ -286,6 +290,17 @@ CGRect frameForUnselectedCard(NSIndexPath *indexPath, NSIndexPath *indexPathSele
     f = CGRectInset(f, (bottomStackedTotalHeight / m.stackedVisibleHeight - itemOrder - 1) * 2.0, 0);
     
     return f;
+}
+
+/** 
+ Returns the number of items in the given section. If the section does not 
+ exist, returns 0 instead of throwing an exception. 
+ */
+- (NSInteger)numberOfItemsInCollectionViewSection:(NSInteger)section {
+    return
+    [self.collectionView numberOfSections] > section ?
+    [self.collectionView numberOfItemsInSection:section] :
+    0;
 }
 
 @end


### PR DESCRIPTION
When there are 0 sections, calling 'numberOfItemsInSection:' throws an exception. This PR returns 0 instead.