### PR TITLE
collapseAll support and implementation

### DIFF
--- a/MTCardLayout/MTCardLayout.m
+++ b/MTCardLayout/MTCardLayout.m
@@ -182,7 +182,7 @@
 		targetContentOffset.y += self.collectionView.contentInset.top;
         CGFloat flexibleHeight = _metrics.flexibleTop;
         if (targetContentOffset.y < flexibleHeight) {
-            targetContentOffset.y = (targetContentOffset.y < flexibleHeight / 2) ? 0.0 : flexibleHeight;
+            targetContentOffset.y = (targetContentOffset.y < flexibleHeight / 2) ? proposedContentOffset.y : flexibleHeight;
         } else {
             if (_metrics.visibleHeight > 0) {
                 targetContentOffset.y = roundf((targetContentOffset.y - flexibleHeight) / _metrics.visibleHeight) * _metrics.visibleHeight + flexibleHeight;

--- a/MTCardLayout/MTCardLayout.m
+++ b/MTCardLayout/MTCardLayout.m
@@ -139,13 +139,13 @@
     effectiveBounds.origin.y += self.collectionView.contentInset.top;
     effectiveBounds.origin.y += _metrics.listingInsets.top;
     effectiveBounds.size.height -= _metrics.listingInsets.top + _metrics.listingInsets.bottom;
-	rect = CGRectIntersection(rect, effectiveBounds);
+	  rect = CGRectIntersection(rect, effectiveBounds);
     
-    NSRange range = rangeForVisibleCells(rect, [self.collectionView numberOfItemsInSection:0] , _metrics);
-    
+    NSInteger numberOfItems = [self numberOfItemsInCollectionViewSection:0];
+    NSRange range = rangeForVisibleCells(rect, numberOfItems, _metrics);
     NSMutableArray *cells = [NSMutableArray arrayWithCapacity:range.length + 2];
     
-	NSIndexPath *selectedIndexPath = [[self.collectionView indexPathsForSelectedItems] firstObject];
+	  NSIndexPath *selectedIndexPath = [[self.collectionView indexPathsForSelectedItems] firstObject];
 
     for (NSUInteger item=range.location; item < (range.location + range.length); item++)
     {
@@ -163,7 +163,7 @@
 
 - (CGSize)collectionViewContentSize
 {
-    return collectionViewSize(self.collectionView.bounds, self.collectionView.contentInset, [self.collectionView numberOfItemsInSection:0], _metrics);
+    return collectionViewSize(self.collectionView.bounds, self.collectionView.contentInset, [self numberOfItemsInCollectionViewSection:0], _metrics);
 }
 
 - (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds
@@ -283,6 +283,16 @@ CGRect frameForUnselectedCard(NSIndexPath *indexPath, NSIndexPath *indexPathSele
     }
     
     return f;
+}
+
+/**
+ Returns the number of items in the given section. If the section does not
+ exist, returns 0 instead of throwing an exception.
+*/
+- (NSInteger)numberOfItemsInCollectionViewSection:(NSInteger)section {
+  return [self.collectionView numberOfSections] > section ?
+  [self.collectionView numberOfItemsInSection:section] :
+  0;
 }
 
 @end

--- a/MTCardLayout/MTCardLayout.m
+++ b/MTCardLayout/MTCardLayout.m
@@ -50,7 +50,7 @@
     m.presentingInsets = UIEdgeInsetsMake(00, 0, 44, 0);
     m.listingInsets = UIEdgeInsetsMake(20.0, 0, 0, 0);
     m.minimumVisibleHeight = 74;
-	m.flexibleTop = 0.0;
+    m.flexibleTop = 0.0;
     m.stackedVisibleHeight = 6.0;
     m.maxStackedCards = 5;
 
@@ -58,7 +58,8 @@
     e.sticksTop         = YES;
     e.bouncesTop        = YES;
     e.spreading         = NO;
-    
+    e.touchToCollapseCard = YES;
+  
     _metrics = m;
     _effects = e;
     
@@ -219,7 +220,7 @@ NSRange rangeForVisibleCells(CGRect rect, NSInteger count, MTCardLayoutMetrics m
 
 CGSize collectionViewSize(CGRect bounds, UIEdgeInsets contentInset, NSInteger count, MTCardLayoutMetrics m)
 {
-	CGFloat height = count * m.visibleHeight + m.flexibleTop + m.listingInsets.top + fmodf(bounds.size.height - contentInset.top - m.listingInsets.top, m.visibleHeight);
+    CGFloat height = count * m.visibleHeight + m.flexibleTop + m.listingInsets.top + fmodf(bounds.size.height - contentInset.top - m.listingInsets.top, m.visibleHeight);
     return CGSizeMake(bounds.size.width, height);
 }
 

--- a/MTCardLayout/MTCardLayout.m
+++ b/MTCardLayout/MTCardLayout.m
@@ -85,6 +85,7 @@
 
 - (void)prepareLayout
 {
+  [super prepareLayout];
 	_metrics.visibleHeight = _metrics.minimumVisibleHeight;
     if (_effects.spreading)
     {
@@ -92,7 +93,10 @@
         if (numberOfCards > 0)
         {
             CGFloat height = (self.collectionView.frame.size.height - self.collectionView.contentInset.top - _metrics.listingInsets.top - _metrics.flexibleTop) / numberOfCards;
-            if (height > _metrics.visibleHeight) _metrics.visibleHeight = height;
+            if (height > _metrics.visibleHeight)
+            {
+              _metrics.visibleHeight = height;
+            }
         }
     }
 }

--- a/MTCardLayout/MTCardLayoutHelper.m
+++ b/MTCardLayout/MTCardLayoutHelper.m
@@ -23,6 +23,7 @@ static NSString * const kContentOffsetKeyPath = @"contentOffset";
         self.collectionView = collectionView;
         self.tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                             action:@selector(handleTapGesture:)];
+        self.tapGestureRecognizer.cancelsTouchesInView = false;
         self.tapGestureRecognizer.delegate = self;
         [self.collectionView addGestureRecognizer:self.tapGestureRecognizer];
         

--- a/MTCardLayout/MTCardLayoutHelper.m
+++ b/MTCardLayout/MTCardLayoutHelper.m
@@ -1,4 +1,5 @@
 #import "MTCardLayoutHelper.h"
+#import "MTCardLayout.h"
 #import "UICollectionView+CardLayout.h"
 
 static int kObservingCollectionViewOffset;
@@ -41,28 +42,28 @@ static NSString * const kContentOffsetKeyPath = @"contentOffset";
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-	if (context == &kObservingCollectionViewOffset) {
+    if (context == &kObservingCollectionViewOffset) {
         UICollectionView *collectionView = self.collectionView;
-        if (collectionView && collectionView.dragging)
-        {
+        if (collectionView && collectionView.dragging) {
             UIEdgeInsets edgeInsets = collectionView.contentInset;
             BOOL bounces = collectionView.bounces;
-            
-            if (collectionView.contentOffset.y < - 100 - edgeInsets.top && collectionView.scrollEnabled)
+            MTCardLayout *layout = (MTCardLayout *)collectionView.collectionViewLayout;
+          
+            if (collectionView.contentOffset.y < - 100 - edgeInsets.top && collectionView.scrollEnabled && [layout isKindOfClass:[MTCardLayout class]] && layout.effects.collapsesAll == true)
             {
                 collectionView.contentInset = UIEdgeInsetsMake(-collectionView.contentOffset.y, edgeInsets.left, edgeInsets.bottom, edgeInsets.right);
                 collectionView.bounces = NO;
-                
+        
                 [self.collectionView setViewMode:MTCardLayoutViewModePresenting animated:YES completion:^(BOOL finished) {
                     collectionView.contentInset = edgeInsets;
                     collectionView.bounces = bounces;
                 }];
             }
         }
-	}
-    else {
-        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
-    }
+  }
+  else {
+      [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+  }
 }
 
 #pragma mark - Tap gesture

--- a/MTCardLayout/MTCardLayoutHelper.m
+++ b/MTCardLayout/MTCardLayoutHelper.m
@@ -87,7 +87,11 @@ static NSString * const kContentOffsetKeyPath = @"contentOffset";
 
 - (void)handleTapGesture:(UITapGestureRecognizer *)gestureRecognizer
 {
-    if (self.viewMode == MTCardLayoutViewModePresenting) {
+    MTCardLayout *layout = (MTCardLayout *)self.collectionView.collectionViewLayout;
+    if (![layout isKindOfClass:[MTCardLayout class]]) {
+      return;
+    }
+    if (layout.effects.touchToCollapseCard == true && self.viewMode == MTCardLayoutViewModePresenting) {
         [self.collectionView setViewMode:MTCardLayoutViewModeDefault animated:YES completion:nil];
         NSArray *selectedIndexPaths = [self.collectionView indexPathsForSelectedItems];
         [selectedIndexPaths enumerateObjectsUsingBlock:^(NSIndexPath * indexPath, NSUInteger idx, BOOL *stop) {

--- a/MTCardLayout/MTCommonTypes.h
+++ b/MTCardLayout/MTCommonTypes.h
@@ -42,7 +42,10 @@ typedef struct
     
     /// Allows all cards to collapse to the bottom
     BOOL collapsesAll;
-    
+  
+    /// Allows to collapse a card in Presenting mode by touching it
+    BOOL touchToCollapseCard;
+  
 } MTCardLayoutEffects;
 
 @protocol UICollectionViewDataSource_Draggable <UICollectionViewDataSource>


### PR DESCRIPTION
CollapseAll behavior is now following the `collapseAll` parameter from the MTCardLayoutEffects structure.  
Also integration of : https://github.com/minhntran/MTCardLayout/pull/4